### PR TITLE
version 0.1.6

### DIFF
--- a/src/functions-mails.php
+++ b/src/functions-mails.php
@@ -15,6 +15,6 @@ namespace Globalis\WP\Cubi;
  */
 function wp_mail_html($to, $subject, $message, $headers = [], $attachments = [])
 {
-    $headers = array_merge(['Content-Type: text/html; charset=' . bloginfo('charset')], $headers);
+    $headers = array_merge(['Content-Type: text/html; charset=' . get_bloginfo('charset')], $headers);
     wp_mail($to, $subject, $message, $headers, $attachments);
 }


### PR DESCRIPTION
- Fix use of `get_bloginfo('charset')` in `wp_mail_html`